### PR TITLE
Improve how-to-upload

### DIFF
--- a/docs/how-to-upload.md
+++ b/docs/how-to-upload.md
@@ -1,31 +1,39 @@
-# Upload SMLM data on [Shareloc.xyz](https://shareloc.xyz)
-### How to:
-- [__Login and authorize shareLoc.xyz to upload files to zenodo on your behalf__](#login-and-authorize-sharelocxyz-to-upload-files-to-zenodo-on-your-behalf)
-- [__Upload samples__](#Upload-samples)    
-- [__Enter the information__](#Enter-the-information)
-- [__Publish Deposit__](#Publish-Deposit)
-- [__Link one deposit to another one__](#link-one-deposit-to-another-one)
+# Upload dataset to [Shareloc.xyz](https://shareloc.xyz)
+
+### Overview
+
+- [Login](#login)
+- [Prepare dataset](#prepare-dataset)    
+- [Enter meta information](#enter-meta-information)
+- [Review and upload](#review-and-upload)
+- [Publish the dataset](#publish-the-dataset)
 
 
-## Login and authorize shareLoc.xyz to upload files to zenodo on your behalf
+## Login
+
+To upload a new dataset, you need to first login to Zenodo and authorize shareLoc.xyz to upload files to zenodo on your behalf.
+
  1. Sign up for a [Zenodo](https://sandbox.zenodo.org) account if you don't have one
- 2. Click on the "+ Upload" button
+ 2. Click the "+ Upload" button
 ![UploadButton](https://user-images.githubusercontent.com/56833522/125454254-6e675ab8-06e3-410f-90ff-03424d086e4d.gif)
 
- 3. Click on "Login to Zenodo"
+ 3. Click "Login to Zenodo"
 ![login_zenodo](https://user-images.githubusercontent.com/56833522/125456157-48b225f4-1ec0-4516-bc0a-63a15800a56b.gif)
 
  4. Go back to shareloc.xyz tab and click again on "Login to Zenodo", authorize shareLoc.xyz to upload files to zenodo on your behalf
 ![authorize](https://user-images.githubusercontent.com/56833522/125457536-e8fc428d-6879-4456-8686-9b1662f2afa1.gif)
 
-## Upload samples
- 1. Click on "+ Start Upload" to create a new deposit
+ 5. Click "+ Start Upload" to create a new deposit
 ![newdeposit](https://user-images.githubusercontent.com/56833522/125461318-cd9d4012-1b57-49e2-97bf-c158072debcc.gif)
 
- 2. Click on "+ NEW SAMPLE" to add sample to the deposit
+## Prepare dataset
+ A dataset are typically consists of many samples and one sample can contain several or more files for different channels or image modality of the same biological sample under the same field of view. ShareLoc.xyz allows you to upload files that belongs to the same sample and have multiple samples in the same dataset.
+ 
+
+ 1. Click "+ NEW SAMPLE" to add sample to the deposit
 ![NewSample](https://user-images.githubusercontent.com/56833522/125461773-7d629ac3-2a95-4809-b408-42d17669e302.gif)
 
- 3. Drag and drop file/files     
+ 1. Drag and drop file/files     
     * __Upload localisation table only__
     ![UploadFile](https://user-images.githubusercontent.com/56833522/125463862-74e69b5f-11d1-4065-bd83-5671d7a9ab77.gif)
     
@@ -34,22 +42,22 @@
     __If you want to upload multiple files for the same sample, please select them by pressing `Ctrl` on your keyboard__
     ![UploadWfAvec](https://user-images.githubusercontent.com/56833522/125464663-1380481f-7f88-4dd0-8db6-15960007eb07.gif)
 
- 4. Click on "Preview & Screenshot" 
-![TakeScreenshotx2](https://user-images.githubusercontent.com/56833522/125471072-984aea9f-f423-4fc3-a63d-be85120166d0.gif)
+ 1. Click "Preview & Screenshot" 
+  ![TakeScreenshotx2](https://user-images.githubusercontent.com/56833522/125471072-984aea9f-f423-4fc3-a63d-be85120166d0.gif)
 
- 5. Click on "Take a screenshot", the screenshot will be displayed on shareloc.xyz as the cover of sample
-![Screenshot](https://user-images.githubusercontent.com/56833522/125472521-689366b9-b989-4fa2-a365-d1644e6b21fa.gif)
+ 1. Click "Take a screenshot", the screenshot will be displayed on shareloc.xyz as the cover of sample
+  ![Screenshot](https://user-images.githubusercontent.com/56833522/125472521-689366b9-b989-4fa2-a365-d1644e6b21fa.gif)
 
-__You could take many screenshots and choose the best one__
-![selectScreenShoot](https://user-images.githubusercontent.com/56833522/125481864-be819680-4510-405b-a510-fcf193a10016.gif)
+  __You could take many screenshots and choose the best one__
+  ![selectScreenShoot](https://user-images.githubusercontent.com/56833522/125481864-be819680-4510-405b-a510-fcf193a10016.gif)
 
-### 6. Repeat step 2-4 if you have more than 1 sample for the same experiment
-__[Click on "+ NEW SAMPLE"](#2-click-on--new-sample-to-add-sample-to-the-deposit) >> [Drag and drop file/files](#3-drag-and-drop-filefiles) >> [Take a screenshot](#4-click-on-preview--screenshot)__
+ 1. Repeat step 2-4 if you have more than 1 sample for the same experiment
+__[Click "+ NEW SAMPLE"](#2-click-on--new-sample-to-add-sample-to-the-deposit) >> [Drag and drop file/files](#3-drag-and-drop-filefiles) >> [Take a screenshot](#4-click-on-preview--screenshot)__
 ![redo2to4x2](https://user-images.githubusercontent.com/56833522/125484624-51039a23-64ba-410f-b61b-00d38538caaa.gif)
 
 ###  :exclamation: If the total size exceeds 50 GB, please separate the dataset into serval deposits, [and link to uploaded datasets](#)
 
-## Enter the information
+## Enter meta information
 Once you drop and drag all the files, enter the related information below
 ![image](https://user-images.githubusercontent.com/56833522/125502838-5cee131f-6006-462d-83b2-ae200727608c.png)
 
@@ -95,18 +103,18 @@ Indicate how this dataset should be cited by others.
 You can [link to other uploaded datasets](#link-one-deposit-to-another-one) or applications.
 For example when you have many sample from one experiment however the deposit size exceeds 50 GB
 
-## Publish Deposit
-After you [enter the information of deposit](#Enter-the-information):
- 1. Click on "OK"
+## Review and upload
+After you [enter the information of deposit](#Enter-the-information), click "OK" and you will see the upload page
 ![OktoUpload](https://user-images.githubusercontent.com/56833522/125510034-b23446aa-e104-4a6d-8145-71120ae02304.gif)
 
- 2. Click on "+ UPLOAD AS NEW DEPOSIT"
-This may take long time
+Click "+ UPLOAD AS NEW DEPOSIT" and the upload will start, this may take some time depending on your files and internet speed.
 ![upload-as-new-depositx2](https://user-images.githubusercontent.com/56833522/125514526-15f92b7e-ffc2-49bb-8a72-08d5e2536fa5.gif)
 
- 3. Click on "PUBLISH"
+
+## Publish the dataset
+
+After uploading, you can click "PUBLISH"
 A doi like `xx.xxxx/zenodo.xxxxxx` will be generated, this doi could also be used to link deposits
 ![Publish](https://user-images.githubusercontent.com/56833522/125517947-7fa785ab-8dc5-4afd-b901-96641d7eef66.gif)
 
-## Link one dataset to another dataset or application
-After upload a new [deposit](#Upload-samples), enter the doi of other related deposit(example: `xx.xxxx/zenodo.xxxxxx`) in [`Links`](#Links)
+ Note: Please check carefully before publishing. It is generally not possible to remove items after they have been published. Changes will be added as a new version, but will not erase the previous version. For some reason if you really want to remove some published item, you can contact Zenodo support.


### PR DESCRIPTION
@baiddd It's good that you already made the docs on how to upload. I just did some adjustment to it, some adjustment on the organization, removed some steps which I think it's not necessary (e.g. check version), I reduced the bold headers because I feel the font was too heavy to read.

Another thought, I feel like the gifs in each line is a bit too disruptive to the flow. For example, you cannot really choose when to start the gif. 

An other idea is to move the markdown content to [imjoy-slides](https://github.com/imjoy-team/imjoy-slides), so the user can follow it slide by slide. what do you think? Could you try to make such slides?